### PR TITLE
Add support to count Chinese characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,8 @@ function word_count(text, wc) {
   if (current_word_count >= 10 && warning_shown == false) {
     show_warning();
   }
+  // replace each Chinese character with a new English word " hanzi "
+  text = text.replace(/[\u4e00-\u9fa5]/g, " hanzi "); 
   text = text.replace(/^\s*|\s*$/g,''); //removes whitespace from front and end
   text = text.replace(/\s+/g,' '); // collapse multiple consecutive spaces
   var words = text.split(" ");


### PR DESCRIPTION
I am a Chinese. I find writtenkitten is designed for English writing and it can not count Chinese characters correctly.

In Chinese writing, we often regard a single Chinese character as a "word" in word count.
Therefore I add a pre-process in word count JS function in writtenkitten. The pre-process firstly transform each Chinese character into a English word ` hanzi `. Then the text will be counted in the previous way which count each word seperated by white-space character.

